### PR TITLE
#57 closable menu

### DIFF
--- a/src/containers/EventsDashboard.js
+++ b/src/containers/EventsDashboard.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { Layout } from 'antd';
 
 import {
   getVisbleEvents,
@@ -22,11 +23,20 @@ import * as selectionActions from '../state/selections/actions';
 import SideBar from './SideBar';
 import MapView from '../components/MapView';
 
+/* eslint-disable */
+require('style-loader!css-loader!antd/es/layout/style/index.css');
+/* eslint-enable */
+
 class EventsDashboard extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       init: true,
+      collapsed: false,
+    };
+    this.onCollapse = (collapsed) => {
+      console.log(collapsed);
+      this.setState({ collapsed });
     };
   }
 
@@ -69,27 +79,41 @@ class EventsDashboard extends React.Component {
     }
 
     return (
-      <div>
+      <Layout>
         <h2 className="dash-title">Event Dashboard</h2>
-        <SideBar
-          colorMap={colorMap}
-          items={visibleEvents}
-          allItems={allEvents}
-          refcode={refcode}
-          type="events"
-          resetSearchByZip={resetSearchByZip}
-        />
-        <MapView
-          items={visibleEvents}
-          center={center}
-          colorMap={colorMap}
-          type="events"
-          filterByValue={{ [filterBy]: [filterValue] }}
-          resetSearchByZip={resetSearchByZip}
-          setLatLng={setLatLng}
-          distance={distance}
-        />
-      </div>
+        <Layout.Sider
+          collapsible
+          collapsed={this.state.collapsed}
+          onCollapse={this.onCollapse}
+          className="sidebar-container"
+        >
+          <SideBar
+            colorMap={colorMap}
+            items={visibleEvents}
+            allItems={allEvents}
+            refcode={refcode}
+            type="events"
+            resetSearchByZip={resetSearchByZip}
+            collapsible
+            collapsed={this.state.collapsed}
+            onCollapse={this.onCollapse}
+          />
+          <div className="sidebar-collapsed-text">Filters & Events</div>
+        </Layout.Sider>
+
+        <Layout>
+          <MapView
+            items={visibleEvents}
+            center={center}
+            colorMap={colorMap}
+            type="events"
+            filterByValue={{ [filterBy]: [filterValue] }}
+            resetSearchByZip={resetSearchByZip}
+            setLatLng={setLatLng}
+            distance={distance}
+          />
+        </Layout>
+      </Layout>
     );
   }
 }

--- a/src/containers/EventsDashboard.js
+++ b/src/containers/EventsDashboard.js
@@ -86,6 +86,7 @@ class EventsDashboard extends React.Component {
           collapsed={this.state.collapsed}
           onCollapse={this.onCollapse}
           className="sidebar-container"
+          breakpoint="lg"
         >
           <SideBar
             colorMap={colorMap}

--- a/src/containers/EventsDashboard.js
+++ b/src/containers/EventsDashboard.js
@@ -23,20 +23,11 @@ import * as selectionActions from '../state/selections/actions';
 import SideBar from './SideBar';
 import MapView from '../components/MapView';
 
-/* eslint-disable */
-require('style-loader!css-loader!antd/es/layout/style/index.css');
-/* eslint-enable */
-
 class EventsDashboard extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       init: true,
-      collapsed: false,
-    };
-    this.onCollapse = (collapsed) => {
-      console.log(collapsed);
-      this.setState({ collapsed });
     };
   }
 
@@ -81,26 +72,18 @@ class EventsDashboard extends React.Component {
     return (
       <Layout>
         <h2 className="dash-title">Event Dashboard</h2>
-        <Layout.Sider
+        <SideBar
+          colorMap={colorMap}
+          items={visibleEvents}
+          allItems={allEvents}
+          refcode={refcode}
+          type="events"
+          resetSearchByZip={resetSearchByZip}
           collapsible
           collapsed={this.state.collapsed}
           onCollapse={this.onCollapse}
-          className="sidebar-container"
-          breakpoint="lg"
-        >
-          <SideBar
-            colorMap={colorMap}
-            items={visibleEvents}
-            allItems={allEvents}
-            refcode={refcode}
-            type="events"
-            resetSearchByZip={resetSearchByZip}
-            collapsible
-            collapsed={this.state.collapsed}
-            onCollapse={this.onCollapse}
-          />
-          <div className="sidebar-collapsed-text">Filters & Events</div>
-        </Layout.Sider>
+          collapsedText="Filters & Events"
+        />
 
         <Layout>
           <MapView

--- a/src/containers/GroupsDashboard.js
+++ b/src/containers/GroupsDashboard.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { Layout } from 'antd';
 import {
   getColorMap,
-
 } from '../state/events/selectors';
 
 import {
@@ -25,20 +24,11 @@ import MapView from '../components/MapView';
 
 import SideBar from './SideBar';
 
-/* eslint-disable */
-require('style-loader!css-loader!antd/es/layout/style/index.css');
-/* eslint-enable */
-
 class GroupsDashboard extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       init: true,
-      collapsed: false,
-    };
-    this.onCollapse = (collapsed) => {
-      console.log(collapsed);
-      this.setState({ collapsed });
     };
   }
 
@@ -80,16 +70,7 @@ class GroupsDashboard extends React.Component {
     return (
       <Layout>
         <h2 className="dash-title">Group Dashboard</h2>
-        <Layout.Sider
-          collapsible
-          collapsed={this.state.collapsed}
-          onCollapse={this.onCollapse}
-          className="sidebar-container"
-        >
-          <SideBar type="groups" items={groups} allItems={allGroups} />
-          <div className="sidebar-collapsed-text">Filters & Groups</div>
-        </Layout.Sider>
-
+        <SideBar type="groups" items={groups} allItems={allGroups} collapsedText="Filters & Groups" />
         <Layout>
           <MapView
             center={center}

--- a/src/containers/GroupsDashboard.js
+++ b/src/containers/GroupsDashboard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { Layout } from 'antd';
 import {
   getColorMap,
 
@@ -24,11 +25,20 @@ import MapView from '../components/MapView';
 
 import SideBar from './SideBar';
 
+/* eslint-disable */
+require('style-loader!css-loader!antd/es/layout/style/index.css');
+/* eslint-enable */
+
 class GroupsDashboard extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       init: true,
+      collapsed: false,
+    };
+    this.onCollapse = (collapsed) => {
+      console.log(collapsed);
+      this.setState({ collapsed });
     };
   }
 
@@ -68,19 +78,30 @@ class GroupsDashboard extends React.Component {
     }
 
     return (
-      <div>
+      <Layout>
         <h2 className="dash-title">Group Dashboard</h2>
-        <SideBar type="groups" items={groups} allItems={allGroups} />
-        <MapView
-          center={center}
-          type="groups"
-          items={groups}
-          colorMap={colorMap}
-          filterByValue={{ [filterBy]: [filterValue] }}
-          resetSearchByZip={resetSelections}
-          distance={distance}
-        />
-      </div>
+        <Layout.Sider
+          collapsible
+          collapsed={this.state.collapsed}
+          onCollapse={this.onCollapse}
+          className="sidebar-container"
+        >
+          <SideBar type="groups" items={groups} allItems={allGroups} />
+          <div className="sidebar-collapsed-text">Filters & Groups</div>
+        </Layout.Sider>
+
+        <Layout>
+          <MapView
+            center={center}
+            type="groups"
+            items={groups}
+            colorMap={colorMap}
+            filterByValue={{ [filterBy]: [filterValue] }}
+            resetSearchByZip={resetSelections}
+            distance={distance}
+          />
+        </Layout>
+      </Layout>
     );
   }
 }

--- a/src/containers/SideBar.js
+++ b/src/containers/SideBar.js
@@ -35,7 +35,7 @@ class SideBar extends React.Component {
     } = this.props;
 
     return (
-      <div>
+      <div className="sidebar">
         <MenuBar items={items} type={type} allItems={allItems} />
         <Table
           colorMap={colorMap}

--- a/src/containers/SideBar.js
+++ b/src/containers/SideBar.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Layout } from 'antd';
 
 import * as selections from '../state/selections/selectors';
 
 import MenuBar from './MenuBar';
 
 import Table from '../components/Table';
+
+/* eslint-disable */
+require('style-loader!css-loader!antd/es/layout/style/index.css');
+/* eslint-enable */
 
 class SideBar extends React.Component {
   constructor(props) {
@@ -32,19 +37,28 @@ class SideBar extends React.Component {
       items,
       refcode,
       type,
+      collapsedText,
     } = this.props;
 
     return (
-      <div className="sidebar">
-        <MenuBar items={items} type={type} allItems={allItems} />
-        <Table
-          colorMap={colorMap}
-          items={items}
-          refcode={refcode}
-          shouldRender={this.renderTable()}
-          type={type}
-        />
-      </div>
+      <Layout.Sider
+        collapsible
+        onCollapse={this.onCollapse}
+        className="sidebar-container"
+        breakpoint="lg"
+      >
+        <div className="sidebar">
+          <MenuBar items={items} type={type} allItems={allItems} />
+          <Table
+            colorMap={colorMap}
+            items={items}
+            refcode={refcode}
+            shouldRender={this.renderTable()}
+            type={type}
+          />
+        </div>
+        <div className="sidebar-collapsed-text">{collapsedText}</div>
+      </Layout.Sider>
     );
   }
 }
@@ -59,6 +73,7 @@ SideBar.propTypes = {
   colorMap: PropTypes.arrayOf(PropTypes.shape({})),
   refcode: PropTypes.string,
   type: PropTypes.string.isRequired,
+  collapsedText: PropTypes.string.isRequired,
 };
 
 SideBar.defaultProps = {

--- a/src/style/app.scss
+++ b/src/style/app.scss
@@ -11,6 +11,7 @@
 @import "./partials/reset";
 @import "./partials/typography";
 @import "./partials/buttons";
+@import "./partials/layouts";
 
 // Components
 @import "./components/map";

--- a/src/style/components/_event-list.scss
+++ b/src/style/components/_event-list.scss
@@ -1,15 +1,8 @@
-#events-list {
-  width: 27.5vw;
+#events-list, #groups-list {
+  width: 100%;
   height: 500px;
-  margin-top: 20vh;
-  overflow: scroll;
-  padding: 200px 20px 20px 20px;
-}
-
-#groups-list {
-  width: 27.5vw;
-  height: 500px;
-  margin-top: 20vh;
-  overflow: scroll;
-  padding: 110px 20px 20px 20px;
+  margin-top: 5vh;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  padding-bottom: 200px; //Offset collapse button
 }

--- a/src/style/components/_filters.scss
+++ b/src/style/components/_filters.scss
@@ -1,6 +1,6 @@
 .content-container-filters {
-  width: 26vw;
-  position: absolute;
+  width: 100%;
+  position: relative;
   background-color: white;
   @include box-3d;
   padding: 1vw;

--- a/src/style/components/_map.scss
+++ b/src/style/components/_map.scss
@@ -5,7 +5,7 @@
   position: absolute;
   top: 20vh;
   bottom: 0;
-  height: 500px;
+  height: 520px;
   width: 72.5vw;
   right: 0;
 }

--- a/src/style/partials/_layouts.scss
+++ b/src/style/partials/_layouts.scss
@@ -24,6 +24,11 @@
     &.ant-layout-sider-collapsed {
         flex: 0 0 5vw!important;
         width: 5vw!important;
+
+        &.ant-layout-sider-below {
+            width: 10vw!important;
+            background: red;
+        }
         
         .ant-layout-sider-children {
             color: #FFF;
@@ -50,6 +55,10 @@
                 width: 100%!important;
                 height: auto!important;
             }
+        }
+
+        &.ant-layout-sider-below + .ant-layout #map.mapboxgl-map {
+            width: 90vw!important;
         }
     }
 

--- a/src/style/partials/_layouts.scss
+++ b/src/style/partials/_layouts.scss
@@ -1,0 +1,61 @@
+.ant-layout {
+    background: none!important;
+}
+
+.sidebar-container.ant-layout-sider {
+    background: none;
+    flex: 0 0 33vw!important;
+    max-width: 33vw!important;
+    width: 33vw!important;
+    height: 520px;
+    overflow: hidden;
+    position: absolute;
+    top: 20vh;
+    left: 0;
+
+    .sidebar-collapsed-text {
+        display: none;
+    }
+
+    & + .ant-layout #map.mapboxgl-map {
+        width: 67vw;
+    }
+
+    &.ant-layout-sider-collapsed {
+        flex: 0 0 5vw!important;
+        width: 5vw!important;
+        
+        .ant-layout-sider-children {
+            color: #FFF;
+            background: #002140;
+        }
+
+        .sidebar {
+            display: none;
+        }
+
+        .sidebar-collapsed-text {
+            display: block;
+            writing-mode: vertical-lr;
+            font-size: 2.5em;
+            height: 100%;
+            text-align: center;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        & + .ant-layout #map.mapboxgl-map {
+            width: 95vw!important;
+            .mapboxgl-canvas {
+                width: 100%!important;
+                height: auto!important;
+            }
+        }
+    }
+
+    .ant-layout-sider-trigger {
+        position: absolute;
+        bottom: 0;
+        width: 100%!important;
+    }
+}


### PR DESCRIPTION
This closes #57.

I really don't like the style overrides required here, but either I'm missing something or ant d doesn't allow this sorta stuff out of the box (the collapsible "Sider"s are all meant for menus afaict).  The whole process left me feeling like I was fighting against the framework instead of working with it.

This should work as is, but could definitely use some TLC later on.