### PR TITLE
Clicking on inset refocuses state bounds to that state

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "classnames": "^2.2.5",
     "css-loader": "^0.28.7",
     "dotenv": "^5.0.0",
-    "express": "^4.16.2",
+    "express": "^4.16.3",
     "extract-text-webpack-plugin": "^3.0.2",
     "history": "4.7.2",
     "html-webpack-plugin": "^2.30.1",

--- a/src/components/EventMap.js
+++ b/src/components/EventMap.js
@@ -25,6 +25,7 @@ class MapView extends React.Component {
     this.districtSelect = this.districtSelect.bind(this);
     this.removeHighlights = this.removeHighlights.bind(this);
     this.filterForStateInsets = this.filterForStateInsets.bind(this);
+    this.insetOnClickEvent = this.insetOnClickEvent.bind(this);
     this.state = {
       alaskaItems: filter(this.props.items, { state: 'AK' }),
       hawaiiItems: filter(this.props.items, { state: 'HI' }),
@@ -106,6 +107,14 @@ class MapView extends React.Component {
       alaskaItems,
       hawaiiItems,
     });
+  }
+
+  insetOnClickEvent(e){
+    const dataBounds = e.target.parentNode.parentNode.getAttribute('data-bounds').split(',');
+    const boundsOne = [parseInt(dataBounds[0]), parseInt(dataBounds[1])];
+    const boundsTwo = [parseInt(dataBounds[2]), parseInt(dataBounds[3])];
+    const bounds = boundsOne.concat(boundsTwo);
+    this.map.fitBounds(bounds);
   }
 
   focusMap(bb) {
@@ -452,6 +461,7 @@ class MapView extends React.Component {
         <div id="map" >
           <div className="map-overlay" id="legend">
             <MapInset
+              onClick={this.insetOnClickEvent}
               items={this.state.alaskaItems}
               center={center}
               colorMap={colorMap}
@@ -468,6 +478,7 @@ class MapView extends React.Component {
               bounds={[[-170.15625, 51.72702815704774], [-127.61718749999999, 71.85622888185527]]}
             />
             <MapInset
+              onClick={this.insetOnClickEvent}
               items={this.state.hawaiiItems}
               center={center}
               colorMap={colorMap}

--- a/src/components/GroupMap.js
+++ b/src/components/GroupMap.js
@@ -23,6 +23,7 @@ class MapView extends React.Component {
     this.districtSelect = this.districtSelect.bind(this);
     this.removeHighlights = this.removeHighlights.bind(this);
     this.filterForStateInsets = this.filterForStateInsets.bind(this);
+    this.insetOnClickEvent = this.insetOnClickEvent.bind(this);
     this.state = {
       alaskaItems: filter(this.props.items, { state: 'AK' }),
       hawaiiItems: filter(this.props.items, { state: 'HI' }),
@@ -91,6 +92,14 @@ class MapView extends React.Component {
       updatedObj = { ...indEvent, icon: colorObj.icon };
     }
     return updatedObj;
+  }
+
+  insetOnClickEvent(e) {
+    const dataBounds = e.target.parentNode.parentNode.getAttribute('data-bounds').split(',');
+    const boundsOne = [parseInt(dataBounds[0], 10), parseInt(dataBounds[1], 10)];
+    const boundsTwo = [parseInt(dataBounds[2], 10), parseInt(dataBounds[3], 10)];
+    const bounds = boundsOne.concat(boundsTwo);
+    this.map.fitBounds(bounds);
   }
 
   focusMap(bb) {
@@ -349,6 +358,7 @@ class MapView extends React.Component {
         <div id="map" >
           <div className="map-overlay" id="legend">
             <MapInset
+              onClick={this.insetOnClickEvent}
               center={center}
               colorMap={colorMap}
               district={district}
@@ -366,6 +376,7 @@ class MapView extends React.Component {
               bounds={[[-170.15625, 51.72702815704774], [-127.61718749999999, 71.85622888185527]]}
             />
             <MapInset
+              onClick={this.insetOnClickEvent}
               center={center}
               colorMap={colorMap}
               district={district}

--- a/src/components/MapInset.js
+++ b/src/components/MapInset.js
@@ -359,7 +359,7 @@ class MapInset extends React.Component {
     });
     return (
       <React.Fragment>
-        <div id={mapId} className={mapClassNames} />
+        <div id={mapId} className={mapClassNames} data-bounds={this.props.bounds} onClick={this.props.onClick}/>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
Issue #93 
Created a function in both EventMap and GroupMap (insetOnClickEvent) that takes the bounds from the inset and applies them to the main map so that only that state shows up in the bounding box