### PR TITLE
Added options to fitBounds on MapInset

### DIFF
--- a/src/components/MapInset.js
+++ b/src/components/MapInset.js
@@ -331,7 +331,10 @@ class MapInset extends React.Component {
     };
     // map on 'load'
     this.map.on('load', () => {
-      this.map.fitBounds(bounds);
+      this.map.fitBounds(bounds, {
+        linear: true,
+        easeTo: {duration: 0}
+      });
       this.addClickListener();
       if (type === 'events') {
         this.addLayer(featuresHome);


### PR DESCRIPTION
Issue #100 
Didn't need to cover the inset, there is an option to set the easeTo animation of the fitBounds function to 0 to get rid of the zoom 