### PR TITLE
Filter inset map fix

### DIFF
--- a/src/components/EventMap.js
+++ b/src/components/EventMap.js
@@ -29,6 +29,7 @@ class MapView extends React.Component {
     this.state = {
       alaskaItems: filter(this.props.items, { state: 'AK' }),
       hawaiiItems: filter(this.props.items, { state: 'HI' }),
+      inset: true,
     };
   }
 
@@ -78,10 +79,14 @@ class MapView extends React.Component {
       return this.focusMap(stateBB);
     }
     if (center.LNG) {
-      return this.map.flyTo({
-        center: [Number(center.LNG), Number(center.LAT)],
-        zoom: 9.52 - (distance * (4.7 / 450)),
-      });
+      if(this.state.inset === false){
+        return this.map.fitBounds(this.map.getBounds());
+      } else {
+        return this.map.flyTo({
+          center: [Number(center.LNG), Number(center.LAT)],
+          zoom: 9.52 - (distance * (4.7 / 450)),
+        });
+      } 
     }
     return this.map.fitBounds([[-128.8, 23.6], [-65.4, 50.2]]);
   }
@@ -110,6 +115,7 @@ class MapView extends React.Component {
   }
 
   insetOnClickEvent(e){
+    this.setState({inset: false});
     const dataBounds = e.target.parentNode.parentNode.getAttribute('data-bounds').split(',');
     const boundsOne = [parseInt(dataBounds[0]), parseInt(dataBounds[1])];
     const boundsTwo = [parseInt(dataBounds[2]), parseInt(dataBounds[3])];
@@ -125,10 +131,10 @@ class MapView extends React.Component {
     const width = window.innerWidth;
     const view = geoViewport.viewport(bb, [width / 2, height / 2]);
     if (view.zoom < 2.5) {
-      view.zoom = 2.5;
-    } else {
-      view.zoom -= 0.5;
-    }
+          view.zoom = 2.5;
+        } else {
+          view.zoom -= 0.5;
+        }
     this.map.flyTo(view);
   }
 
@@ -389,6 +395,7 @@ class MapView extends React.Component {
   handleReset() {
     this.removeHighlights();
     this.props.resetSelections();
+    this.setState({inset: true})
   }
   // Creates the button in our zoom controls to go to the national view
   makeZoomToNationalButton() {

--- a/src/components/GroupMap.js
+++ b/src/components/GroupMap.js
@@ -27,6 +27,7 @@ class MapView extends React.Component {
     this.state = {
       alaskaItems: filter(this.props.items, { state: 'AK' }),
       hawaiiItems: filter(this.props.items, { state: 'HI' }),
+      inset: true,
     };
   }
 
@@ -72,7 +73,10 @@ class MapView extends React.Component {
       return this.focusMap(stateBB);
     }
     if (center.LNG) {
-      return this.map.flyTo({
+      if (this.state.inset === false) {
+        return this.map.fitBounds(this.map.getBounds());
+      }
+        return this.map.flyTo({
         center: [Number(center.LNG), Number(center.LAT)],
         zoom: 9.52 - (distance * (4.7 / 450)),
       });
@@ -95,6 +99,7 @@ class MapView extends React.Component {
   }
 
   insetOnClickEvent(e) {
+    this.setState({ inset: false });
     const dataBounds = e.target.parentNode.parentNode.getAttribute('data-bounds').split(',');
     const boundsOne = [parseInt(dataBounds[0], 10), parseInt(dataBounds[1], 10)];
     const boundsTwo = [parseInt(dataBounds[2], 10), parseInt(dataBounds[3], 10)];
@@ -291,6 +296,7 @@ class MapView extends React.Component {
   handleReset() {
     this.removeHighlights();
     this.props.resetSelections();
+    this.setState({ inset: true });
   }
   // Creates the button in our zoom controls to go to the national view
   makeZoomToNationalButton() {

--- a/src/components/GroupMap.js
+++ b/src/components/GroupMap.js
@@ -76,7 +76,7 @@ class MapView extends React.Component {
       if (this.state.inset === false) {
         return this.map.fitBounds(this.map.getBounds());
       }
-        return this.map.flyTo({
+      return this.map.flyTo({
         center: [Number(center.LNG), Number(center.LAT)],
         zoom: 9.52 - (distance * (4.7 / 450)),
       });

--- a/src/components/MapInset.js
+++ b/src/components/MapInset.js
@@ -100,28 +100,28 @@ class MapInset extends React.Component {
       closeOnClick: true,
     });
 
-    map.on('mousemove', (e) => {
-      const { searchType } = this.map.metadata;
-      const features = map.queryRenderedFeatures(e.point, { layers: [layer] });
-      // Change the cursor style as a UI indicator.
-      map.getCanvas().style.cursor = (features.length) ? 'pointer' : '';
+    // map.on('mousemove', (e) => {
+    //   const { searchType } = this.map.metadata;
+    //   const features = map.queryRenderedFeatures(e.point, { layers: [layer] });
+    //   // Change the cursor style as a UI indicator.
+    //   map.getCanvas().style.cursor = (features.length) ? 'pointer' : '';
 
-      if (features.length) {
-        const feature = features[0];
-        const { properties } = feature;
-        const linkMapping = {
-          events: `<a target="_blank" href=${properties.rsvpHref}${refcode}>rsvp</a>`,
-          groups: '',
-        };
-        return popup.setLngLat(feature.geometry.coordinates)
-          .setHTML(`
-              <h4>${feature.properties.title}</h4>
-              <div>${feature.properties.startsAt}</div>
-              ${linkMapping[type]}
-              `)
-          .addTo(map);
-      }
-    });
+    //   if (features.length) {
+    //     const feature = features[0];
+    //     const { properties } = feature;
+    //     const linkMapping = {
+    //       events: `<a target="_blank" href=${properties.rsvpHref}${refcode}>rsvp</a>`,
+    //       groups: '',
+    //     };
+    //     return popup.setLngLat(feature.geometry.coordinates)
+    //       .setHTML(`
+    //           <h4>${feature.properties.title}</h4>
+    //           <div>${feature.properties.startsAt}</div>
+    //           ${linkMapping[type]}
+    //           `)
+    //       .addTo(map);
+    //   }
+    // });
   }
 
   districtSelect(feature) {
@@ -191,7 +191,7 @@ class MapInset extends React.Component {
             LNG: e.lngLat.lng.toString(),
           };
         }
-        setLatLng(formatLatLng);
+        //setLatLng(formatLatLng);
       } else if (searchType === 'district') {
         const features = map.queryRenderedFeatures(
           e.point,
@@ -213,7 +213,7 @@ class MapInset extends React.Component {
               LAT: point.geometry.coordinates[1].toString(),
               LNG: point.geometry.coordinates[0].toString(),
             };
-            setLatLng(formatLatLng);
+            //setLatLng(formatLatLng);
           } else {
             searchByDistrict({ state: feature.state, district: feature.district });
           }

--- a/src/components/MapInset.js
+++ b/src/components/MapInset.js
@@ -191,7 +191,7 @@ class MapInset extends React.Component {
             LNG: e.lngLat.lng.toString(),
           };
         }
-        //setLatLng(formatLatLng);
+        setLatLng(formatLatLng);
       } else if (searchType === 'district') {
         const features = map.queryRenderedFeatures(
           e.point,
@@ -213,7 +213,7 @@ class MapInset extends React.Component {
               LAT: point.geometry.coordinates[1].toString(),
               LNG: point.geometry.coordinates[0].toString(),
             };
-            //setLatLng(formatLatLng);
+            setLatLng(formatLatLng);
           } else {
             searchByDistrict({ state: feature.state, district: feature.district });
           }


### PR DESCRIPTION
This is a fix for a previous pull request: 
If you toggled a filter while main map was on Hawaii or Alaska view, it would zoom in to the coordinates. To get it to stay in place I added this.state.inset, then changed ComponentWillRecieveProps, that instead of flyTo automatically, it only does it if inset is true. Goodness.

While I was in there, also disabled popovers in the insets: issue #99 